### PR TITLE
Fix RedHat-style locked accounts (systemd-*)

### DIFF
--- a/user_group_password_helper.inc
+++ b/user_group_password_helper.inc
@@ -81,8 +81,8 @@ check_shadow () {
             if ($2 == "")
                     printf("Login %s has no password.\n", $1);
         if ($2 != "" && length($2) != 13 && length($2) != 34 &&
-            length($2) != 1 && $2 !~ /^\$[0-9a-f]+\$/)
-            printf("Login %s has an unsual password field length\n", $1);
+            length($2) != 1 && $2 !~ /^\$[0-9a-f]+\$/ && $2 !~ /^!!$/)
+            printf("Login %s has an unusual password field length\n", $1);
     }' < $PW > "$output_file"
     if [ -s "$output_file" ] ; then
             printf "\nChecking the $PW file:\n"


### PR DESCRIPTION
openSUSE creates several user accounts like the following:
```
# grep '!!' /etc/shadow
systemd-bus-proxy:!!:17556::::::
systemd-timesync:!!:17556::::::
systemd-network:!!:17595::::::
```

This seems to be the RedHat default behavior (https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/System_Administration_Guide/s2-redhat-config-users-process.html, via https://unix.stackexchange.com/questions/252016/difference-between-vs-vs-in-etc-shadow) and also kind-of-legal on openSUSE ("man 5 shadow" on openSUSE Leap 42.3):
```
encrypted password
    Refer to crypt(3) for details on how this string is interpreted.

    If the password field contains some string that is not a valid result of crypt(3), for
    instance ! or *, the user will not be able to use a unix password to log in (but the user
    may log in the system by other means).

    This field may be empty, in which case no passwords are required to authenticate as the
    specified login name. However, some applications which read the /etc/shadow file may decide
    not to permit any access at all if the password field is empty.

    A password field which starts with a exclamation mark means that the password is locked.
    The remaining characters on the line represent the password field before the password was
    locked.
```
(It is unclear to me and I could not find documentation about what "a valid result of crypt(3)" is.)

Anyway, seccheck doesn't like these entries very much:
```
Checking the /etc/shadow file:
Login systemd-bus-proxy has an unsual password field length
Login systemd-timesync has an unsual password field length
Login systemd-network has an unsual password field length
```

This patch fixes this specific issue and the related typo.